### PR TITLE
Fixes #2: Use Goroutines

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,10 +27,6 @@ var listCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		list, err := sel.List()
-		if err != nil {
-			log.Fatal(err)
-		}
 		tmpl, err := template.New("main").Parse("{{if .Active}}*{{end}}\t{{.Name}}\t{{.Driver}}\t{{if not .State}}Unknown{{else}}{{.State}}{{end}}\n")
 		if err != nil {
 			log.Fatal(err)
@@ -42,7 +38,7 @@ var listCmd = &cobra.Command{
 		if sel.Selected() != nil {
 			selected = *sel.Selected()
 		}
-		for _, entry := range list {
+		for entry := range sel.List() {
 			tmpl.Execute(w, activeEntry{
 				EnvironmentEntryWithState: entry,
 				Active: selected == entry.Name,

--- a/selector/common/types.go
+++ b/selector/common/types.go
@@ -10,7 +10,7 @@ type Driver interface {
 	// Removes the envionment passed from the storage
 	Remove(EnvironmentEntry) error
 	// Lists all environments from this driver
-	List() ([]EnvironmentEntryWithState, error)
+	List() <-chan EnvironmentEntryWithState
 	// Returns environment variables that need to be set
 	Env(EnvironmentEntryWithState) (map[string]*string, error)
 	// Checks if the driver is supported

--- a/selector/drivers/docker_for_mac/docker_for_mac.go
+++ b/selector/drivers/docker_for_mac/docker_for_mac.go
@@ -47,10 +47,15 @@ func (driver DockerForMacDriver) Add(entry common.EnvironmentEntry) error {
 }
 
 // Lists always one entry representing Docker for Mac
-func (driver DockerForMacDriver) List() ([]common.EnvironmentEntryWithState, error) {
-	list := make([]common.EnvironmentEntryWithState, 0)
-	list = append(list, driver.getDockerForMacEntry())
-	return list, nil
+func (driver DockerForMacDriver) List() <-chan common.EnvironmentEntryWithState {
+	list := make(chan common.EnvironmentEntryWithState)
+
+	go func(c chan common.EnvironmentEntryWithState) {
+		c <- driver.getDockerForMacEntry()
+		close(c)
+	}(list)
+
+	return list
 }
 
 func (driver DockerForMacDriver) getDockerForMacEntry() common.EnvironmentEntryWithState {


### PR DESCRIPTION
### Description
Use Goroutines to list entries, each driver now generates a channel to list it's entries, so fan in is used to merge channels together, now there is no way to return error so `panic(err)` is used instead