### PR TITLE
Rename packages in favor of Go's naming convention

### DIFF
--- a/selector/drivers/dockerformac/dockerformac.go
+++ b/selector/drivers/dockerformac/dockerformac.go
@@ -1,5 +1,5 @@
-// docker_for_mac package contains Docker for Mac driver implementation
-package docker_for_mac
+// dockerformac package contains Docker for Mac driver implementation
+package dockerformac
 
 import "errors"
 import "os"

--- a/selector/drivers/dockermachine/dockermachine.go
+++ b/selector/drivers/dockermachine/dockermachine.go
@@ -1,5 +1,5 @@
-// docker_machine package contains docker-machine driver implementation
-package docker_machine
+// dockermachine package contains docker-machine driver implementation
+package dockermachine
 
 import "os/exec"
 import "encoding/json"

--- a/selector/selector.go
+++ b/selector/selector.go
@@ -6,8 +6,8 @@ import "sync"
 import "os"
 
 import "github.com/fmenezes/docker-set/selector/common"
-import "github.com/fmenezes/docker-set/selector/drivers/docker_for_mac"
-import "github.com/fmenezes/docker-set/selector/drivers/docker_machine"
+import "github.com/fmenezes/docker-set/selector/drivers/dockerformac"
+import "github.com/fmenezes/docker-set/selector/drivers/dockermachine"
 import "github.com/fmenezes/docker-set/selector/drivers/vagrant"
 import "github.com/fmenezes/docker-set/selector/storage"
 
@@ -23,12 +23,12 @@ func NewSelector() (*Selector, error) {
 		drivers: make([]common.Driver, 0),
 	}
 
-	dockerForMacDriver := docker_for_mac.NewDriver()
+	dockerForMacDriver := dockerformac.NewDriver()
 	if dockerForMacDriver.IsSupported() {
 		selector.registerDriver(dockerForMacDriver)
 	}
 
-	dockerMachineDriver := docker_machine.NewDriver()
+	dockerMachineDriver := dockermachine.NewDriver()
 	if dockerMachineDriver.IsSupported() {
 		selector.registerDriver(dockerMachineDriver)
 	}


### PR DESCRIPTION
### Description
Renaming packages `docker_for_mac` to `dockerformac` and `docker_machine` to `dockermachine`
